### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     [console_scripts]
     zenml=zenml.cli.cli:cli
     """,
-    python_requires=">=3.6, <3.9",
+    python_requires=">=3.6, <3.9.0",
     license='Apache License 2.0',  # noqa
     author='maiot GmbH',
     author_email='support@maiot.io',


### PR DESCRIPTION
Fixes issues with Arch LInux not being able to run the install due to version mismatch due to missing dot number. 