### PR TITLE
Splitgen skip fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ local_test/
 test.py
 !cloudbuild.yaml
 docs/book/_build/
+
+# macOS specific
+.DS_Store

--- a/docs/book/_toc.yml
+++ b/docs/book/_toc.yml
@@ -57,8 +57,11 @@
   chapters:
   - file: steps/what-is-a-step
     title: What is a step?
-  - file: steps/split
+  - file: steps/split/built-in.md
     title: Split
+    sections:
+      - file: steps/split/custom-split
+        title: Custom Split
   - file: steps/preprocess
     title: Preprocess
   - file: steps/trainer
@@ -67,11 +70,7 @@
     title: Evaluator
   - file: steps/deployer
     title: Deployer
-  - file: steps/custom_steps/custom-steps
-    title: Custom Steps
-    sections:
-      - file: steps/custom_steps/custom-split
-        title: Custom Split
+
 
 - part: Backends
   chapters:

--- a/docs/book/steps/custom_steps/custom-steps.md
+++ b/docs/book/steps/custom_steps/custom-steps.md
@@ -1,3 +1,0 @@
-# Custom Steps
-
-You can create your own steps in ZenML. Here is how

--- a/docs/book/steps/split.md
+++ b/docs/book/steps/split.md
@@ -1,8 +1,0 @@
----
-description: Can you do the splits?
----
-
-# Split
-
-Talk about split steps in general
-

--- a/docs/book/steps/split/built-in.md
+++ b/docs/book/steps/split/built-in.md
@@ -1,12 +1,12 @@
 # Data splits in ZenML
 
-### Motivation
+## Motivation
 
 Data splits are a well-known mechanic in Deep Learning workflows. The main reason behind splitting your data is to
 validate that your trained model is indeed improving by obtaining its predictions and measuring its performance on
 unseen data.
 
-### Internals
+## Internals
 
 In ZenML, we are applying the same split paradigm on datasets of potentially enormous sizes. As a result, any code that
 we write for splitting data has to work for datasets of different sizes, regardless of whether they are in the order of
@@ -113,83 +113,10 @@ as the categorical values of interest. The `split_ratio` map indicates that thes
 into `train` and `eval` sets, with 50% of these categories assigned to either split. The `unknown_category_policy` flag
 works just as in the domain split.
 
-### Creating your own split logic
-
-If the above options are not what you are looking for, there is also the option of implementing your own!
-
-For this, ZenML provides the `BaseSplit` interface that you can subclass in a standard object-oriented manner to define
-your own custom split logic.
-
-```
-from zenml.core.steps.split.base_split_step import BaseSplit
-
-class MyCustomSplit(BaseSplit):
-
-(... your custom split logic follows)
-```
-
-There are two main abstract methods that you have to implement to be able to use your custom split with ZenML's own
-split component, `partition_fn` and `get_split_names`. The former returns your custom partition function along with its
-keyword arguments for use in ZenML's split component. To be eligible in use in a Split Step, the partition function
-needs to adhere to the following design contract:
-
-1. The signature is of the following type:
-
-```
-def my_partition(element, n, **kwargs) -> int,
-```
-
-where n is the number of splits.
-
-2. The partition_fn only returns signed integers i less than n, i.e. 0 ≤ i ≤ n - 1.
-
-Then, the class method `partition_fn` returns the tuple `(my_partition, kwargs)` consisting of your custom partition
-function and its keyword arguments.
-
-The second method `get_split_names` needs to return a list of data split names used in your ZenML pipeline. These can be
-different depending on your target workload.
-
-### A quick example
-
-Now that the theoretical flow is in place, we can quickly give an example by building a partition function that splits
-data into `train` and `eval` sets based on whether an integer feature in the data is odd or even.
-
-```
-from zenml.core.steps.split.base_split_step import BaseSplit
-from zenml.core.steps.split.utils import get_categorical_value
-
-def OddEvenPartitionFn(element, num_partitions, int_feature):
-
-    # get integer value of int_feature from the element
-    int_value = get_categorical_value(element, int_feature)
-    
-    return int_value % 2
-
-class OddEvenSplit(BaseSplit):
-    def __init__(self, 
-                 int_feature: Text,
-                 statistics=None,
-                 schema=None):
-                 
-        self.int_feature = int_feature
-        super().__init__(statistics=statistics,
-                         schema=schema,
-                         int_feature=int_feature)
-        
-    def partition_fn(self):
-        return OddEvenPartitionFn, {"int_feature": self.int_feature}
-    
-    def get_split_names(self):
-        return ["train", "eval"]
-```
-
-Note that we could **not** have done the same logic with a categorical split, since the split above does not assume 
-any knowledge about which integers are present beforehand. For a categorical split to work as built into ZenML, prior
-knowledge about the categorical domain of the feature has to be present.
 
 ## Summary
 
 This concludes our small documentation piece on splitting data with ZenML. Both random, percentage-based splits and
 categorical value-based splits are implemented in ZenML and immediately ready for use. If those do not meet your needs,
-there is also the option of creating your own custom split by overriding the `BaseSplit` class methods. And with that,
+there is also the option of [creating your own custom split](custom-split.md) by overriding the `BaseSplit` class methods. And with that,
 happy splitting!

--- a/docs/book/steps/split/built-in.md
+++ b/docs/book/steps/split/built-in.md
@@ -78,16 +78,14 @@ In the above example, all data points that have either `value_1` or `value_2` as
 will be put into the `train` split, while all data points with either `value_3` or `value_4` will be put into the
 `eval` split.
 
-An important thing to note is the `unknown_category_policy="skip"` flag. This setting controls how categorical values
-are handled that appear in the data but were not specified in the `split_map` argument on construction. A value
-of `"skip"`
+An important thing to note is the `unknown_category_policy` flag. This setting controls how categorical values are
+handled that appear in the data but were not specified in the `split_map` argument on construction. A value of `"skip"`
 denotes that those categories are meant to be discarded from the data set, and will not appear in any of the resulting
 splits as a result.
 
 Setting `unknown_category_policy` to any split name (i.e. so that it equals any of the keys in the split map) will
-assign any categorical values not in the split map to that particular split.
-
-Example: `unknown_category_policy="train"` will assign any unknown categorical value to the "train" split.
+assign any categorical values not in the split map to that particular split. For
+example, `unknown_category_policy="train"` will assign any unknown categorical value to the `"train"` split.
 
 #### 2. Creating a categorical ratio split
 
@@ -113,10 +111,34 @@ as the categorical values of interest. The `split_ratio` map indicates that thes
 into `train` and `eval` sets, with 50% of these categories assigned to either split. The `unknown_category_policy` flag
 works just as in the domain split.
 
+### The importance of the `unknown_category_policy` flag
+
+The categorical split is a powerful tool when you need to group your data by an important categorical feature. In
+addition to data grouping, it serves the additional purpose of _data selection_: By using
+the `unknown_category_policy="skip"` option, you are effectively filtering the data you pass on to your machine learning
+pipeline based on your categorical attribute, by selecting only data with the specific values that you defined in your
+split step. This mimics data selection mechanisms such as `WHERE` clauses in SQL, and can potentially not only save you
+a lot of time and computational effort in pre-processing and model training, but also improve the predicting power of
+your resulting model.
+
+If you want to keep data with unknown / uninteresting categorical values out of your training/eval datasets, but you do
+not want to just throw it away completely, either, then you can also make a completely new split with all excess data by
+specifying your split_map like this:
+
+```
+split = CategoricalDomainSplit(categorical_column="my_categorical_column",
+                               split_map = {"train": ["value_1", "value_2"],
+                                            "eval": ["value_3", "value_4"],
+                                            "test": []},
+                               unknown_category_policy="test")
+```
+
+This way, all data with values for `my_categorical_column` other than `value_{1-4}` will go into the test split and
+still be available for other components downstream.
 
 ## Summary
 
 This concludes our small documentation piece on splitting data with ZenML. Both random, percentage-based splits and
 categorical value-based splits are implemented in ZenML and immediately ready for use. If those do not meet your needs,
-there is also the option of [creating your own custom split](custom-split.md) by overriding the `BaseSplit` class methods. And with that,
-happy splitting!
+there is also the option of [creating your own custom split](custom-split.md) by overriding the `BaseSplit` class
+methods. And with that, happy splitting!

--- a/docs/book/steps/split/custom-split.md
+++ b/docs/book/steps/split/custom-split.md
@@ -1,0 +1,73 @@
+# Creating your own split logic
+
+If the previous built-in options are not what you are looking for, there is also the option of implementing your own!
+
+For this, ZenML provides the `BaseSplit` interface that you can subclass in a standard object-oriented manner to define
+your own custom split logic.
+
+```
+from zenml.core.steps.split.base_split_step import BaseSplit
+
+class MyCustomSplit(BaseSplit):
+
+(... your custom split logic follows)
+```
+
+There are two main abstract methods that you have to implement to be able to use your custom split with ZenML's own
+split component, `partition_fn` and `get_split_names`. The former returns your custom partition function along with its
+keyword arguments for use in ZenML's split component. To be eligible in use in a Split Step, the partition function
+needs to adhere to the following design contract:
+
+1. The signature is of the following type:
+
+```
+def my_partition(element, n, **kwargs) -> int,
+```
+
+where n is the number of splits.
+
+2. The partition_fn only returns signed integers i less than n, i.e. 0 ≤ i ≤ n - 1.
+
+Then, the class method `partition_fn` returns the tuple `(my_partition, kwargs)` consisting of your custom partition
+function and its keyword arguments.
+
+The second method `get_split_names` needs to return a list of data split names used in your ZenML pipeline. These can be
+different depending on your target workload.
+
+## A quick example
+
+Now that the theoretical flow is in place, we can quickly give an example by building a partition function that splits
+data into `train` and `eval` sets based on whether an integer feature in the data is odd or even.
+
+```
+from zenml.core.steps.split.base_split_step import BaseSplit
+from zenml.core.steps.split.utils import get_categorical_value
+
+def OddEvenPartitionFn(element, num_partitions, int_feature):
+
+    # get integer value of int_feature from the element
+    int_value = get_categorical_value(element, int_feature)
+    
+    return int_value % 2
+
+class OddEvenSplit(BaseSplit):
+    def __init__(self, 
+                 int_feature: Text,
+                 statistics=None,
+                 schema=None):
+                 
+        self.int_feature = int_feature
+        super().__init__(statistics=statistics,
+                         schema=schema,
+                         int_feature=int_feature)
+        
+    def partition_fn(self):
+        return OddEvenPartitionFn, {"int_feature": self.int_feature}
+    
+    def get_split_names(self):
+        return ["train", "eval"]
+```
+
+Note that we could **not** have done the same logic with a categorical split, since the split above does not assume 
+any knowledge about which integers are present beforehand. For a categorical split to work as built into ZenML, prior
+knowledge about the categorical domain of the feature has to be present.

--- a/zenml/core/components/split_gen/executor.py
+++ b/zenml/core/components/split_gen/executor.py
@@ -88,8 +88,12 @@ class Executor(BaseExecutor):
         # Get output split path
         examples_artifact = artifact_utils.get_single_instance(
             output_dict[constants.OUTPUT_EXAMPLES])
-        examples_artifact.split_names = artifact_utils.encode_split_names(
-            split_names)
+        if SKIP in split_names:
+            examples_artifact.split_names = artifact_utils.encode_split_names(
+                split_names[:-1])
+        else:
+            examples_artifact.split_names = artifact_utils.encode_split_names(
+                split_names)
 
         split_uris = []
         for artifact in input_dict[constants.INPUT_EXAMPLES]:

--- a/zenml/core/components/split_gen/executor.py
+++ b/zenml/core/components/split_gen/executor.py
@@ -89,8 +89,9 @@ class Executor(BaseExecutor):
         examples_artifact = artifact_utils.get_single_instance(
             output_dict[constants.OUTPUT_EXAMPLES])
         if SKIP in split_names:
+            sanitized_names = [name for name in split_names if name != SKIP]
             examples_artifact.split_names = artifact_utils.encode_split_names(
-                split_names[:-1])
+                sanitized_names)
         else:
             examples_artifact.split_names = artifact_utils.encode_split_names(
                 split_names)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

This PR fixes a bug introduced by my previous PR on categorical splits. The issue was that even though splits are ignored on write time by checking against the SKIP flag, all split names returned by the SplitStep were encoded in the output artifact, including SKIP. This is now fixed by removing SKIP from the output split names by list comprehension. 

Additionally, I added the .DS_Store to the .gitignore file to suppress these files from my local Git on macOS. 
