### PR TITLE
Training splits

### DIFF
--- a/zenml/components/evaluator/executor.py
+++ b/zenml/components/evaluator/executor.py
@@ -103,9 +103,7 @@ class Executor(base_executor.BaseExecutor):
             # Main pipeline
             logging.info('Evaluating model.')
             with self._make_beam_pipeline() as pipeline:
-                examples_list = []
                 tensor_adapter_config = None
-
                 if tfma.is_batched_input(eval_shared_model, eval_config):
                     tfxio_factory = tfxio_utils.get_tfxio_factory_from_artifact(
                         examples=[
@@ -114,29 +112,22 @@ class Executor(base_executor.BaseExecutor):
                         telemetry_descriptors=_TELEMETRY_DESCRIPTORS,
                         schema=schema,
                         raw_record_column_name=tfma_constants.ARROW_INPUT_COLUMN)
-                    for split in evaluator_step.splits:
-                        file_pattern = io_utils.all_files_pattern(
-                            artifact_utils.get_split_uri(examples_artifact,
-                                                         split))
-                        tfxio = tfxio_factory(file_pattern)
-                        data = (pipeline
-                                | 'ReadFromTFRecordToArrow[%s]' % split >> tfxio.BeamSource())
-                        examples_list.append(data)
+
+                    file_pattern = io_utils.all_files_pattern(
+                        artifact_utils.get_single_uri(examples_artifact))
+                    tfxio = tfxio_factory(file_pattern)
+                    data = (pipeline
+                            | 'ReadFromTFRecordToArrow' >> tfxio.BeamSource())
                     if schema is not None:
                         tensor_adapter_config = tensor_adapter.TensorAdapterConfig(
                             arrow_schema=tfxio.ArrowSchema(),
                             tensor_representations=tfxio.TensorRepresentations())
                 else:
-                    for split in evaluator_step.splits:
-                        file_pattern = io_utils.all_files_pattern(
-                            artifact_utils.get_split_uri(examples_artifact,
-                                                         split))
-                        data = (pipeline
-                                | 'ReadFromTFRecord[%s]' % split >>
-                                beam.io.ReadFromTFRecord(
-                                    file_pattern=file_pattern)
-                                )
-                        examples_list.append(data)
+                    file_pattern = io_utils.all_files_pattern(
+                        artifact_utils.get_single_uri(examples_artifact))
+                    data = (pipeline
+                            | 'ReadFromTFRecord' >> beam.io.ReadFromTFRecord(
+                                file_pattern=file_pattern))
 
                 # Resolve custom extractors
                 custom_extractors = try_get_fn(evaluator_step.CUSTOM_MODULE,
@@ -159,8 +150,7 @@ class Executor(base_executor.BaseExecutor):
                         tensor_adapter_config=tensor_adapter_config)
 
                 # Extract, evaluate and write
-                (examples_list | 'FlattenExamples' >> beam.Flatten()
-                 |
+                (data |
                  'ExtractEvaluateAndWriteResults' >> tfma.ExtractEvaluateAndWriteResults(
                             eval_config=eval_config,
                             eval_shared_model=eval_shared_model,

--- a/zenml/components/split_gen/component.py
+++ b/zenml/components/split_gen/component.py
@@ -56,8 +56,7 @@ class SplitGen(BaseComponent):
                  examples: types.Channel = None,  # output
                  statistics: types.Channel = None,
                  schema: types.Channel = None):
-        examples = examples or types.Channel(
-            type=standard_artifacts.Examples)
+        examples = examples or types.Channel(type=standard_artifacts.Examples)
 
         spec = SplitGenComponentSpec(
             source=source,

--- a/zenml/components/trainer/component.py
+++ b/zenml/components/trainer/component.py
@@ -24,13 +24,6 @@ class ZenMLTrainerSpec(ComponentSpec):
         constants.RUN_FN: ExecutionParameter(type=(str, Text), optional=True),
         constants.CUSTOM_CONFIG: ExecutionParameter(type=(str, Text),
                                                     optional=True),
-
-        constants.TRAIN_SPLITS: ExecutionParameter(type=List[Text],
-                                                   optional=True),
-        constants.TEST_SPLITS: ExecutionParameter(type=List[Text],
-                                                  optional=True),
-        constants.EVAL_SPLITS: ExecutionParameter(type=List[Text],
-                                                  optional=True)
     }
     INPUTS = {
         constants.EXAMPLES: ChannelParameter(type=Examples),

--- a/zenml/components/trainer/component.py
+++ b/zenml/components/trainer/component.py
@@ -2,13 +2,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from typing import Any, Dict, Optional, Text, Union
+from typing import Any, Dict, Optional, Text, Union, List
 
 from tfx import types
 from tfx.dsl.components.base import base_component
 from tfx.dsl.components.base import executor_spec
 from tfx.orchestration import data_types
-from tfx.proto import trainer_pb2
 from tfx.types.component_spec import ChannelParameter
 from tfx.types.component_spec import ComponentSpec
 from tfx.types.component_spec import ExecutionParameter
@@ -22,25 +21,31 @@ from zenml.components.trainer.executor import ZenMLTrainerExecutor
 
 class ZenMLTrainerSpec(ComponentSpec):
     PARAMETERS = {
-        'train_args': ExecutionParameter(type=trainer_pb2.TrainArgs),
-        'eval_args': ExecutionParameter(type=trainer_pb2.EvalArgs),
-        'module_file': ExecutionParameter(type=(str, Text), optional=True),
-        'run_fn': ExecutionParameter(type=(str, Text), optional=True),
-        'trainer_fn': ExecutionParameter(type=(str, Text), optional=True),
-        'custom_config': ExecutionParameter(type=(str, Text), optional=True),
+        constants.RUN_FN: ExecutionParameter(type=(str, Text), optional=True),
+        constants.CUSTOM_CONFIG: ExecutionParameter(type=(str, Text),
+                                                    optional=True),
+
+        constants.TRAIN_SPLITS: ExecutionParameter(type=List[Text],
+                                                   optional=True),
+        constants.TEST_SPLITS: ExecutionParameter(type=List[Text],
+                                                  optional=True),
+        constants.EVAL_SPLITS: ExecutionParameter(type=List[Text],
+                                                  optional=True)
     }
     INPUTS = {
-        'examples': ChannelParameter(type=Examples),
-        'schema': ChannelParameter(type=Schema, optional=True),
-        'base_model': ChannelParameter(type=Model, optional=True),
-        'transform_graph': ChannelParameter(type=TransformGraph,
-                                            optional=True),
-        'hyperparameters': ChannelParameter(type=HyperParameters,
-                                            optional=True),
+        constants.EXAMPLES: ChannelParameter(type=Examples),
+        constants.SCHEMA: ChannelParameter(type=Schema,
+                                           optional=True),
+        constants.BASE_MODEL: ChannelParameter(type=Model,
+                                               optional=True),
+        constants.TRANSFORM_GRAPH: ChannelParameter(type=TransformGraph,
+                                                    optional=True),
+        constants.HYPERPARAMETERS: ChannelParameter(type=HyperParameters,
+                                                    optional=True),
     }
     OUTPUTS = {
-        'model': ChannelParameter(type=Model),
-        'model_run': ChannelParameter(type=ModelRun),
+        constants.MODEL: ChannelParameter(type=Model),
+        constants.MODEL_RUN: ChannelParameter(type=ModelRun),
         constants.TEST_RESULTS: ChannelParameter(type=Examples)
     }
 
@@ -61,13 +66,7 @@ class Trainer(base_component.BaseComponent):
             schema: Optional[types.Channel] = None,
             base_model: Optional[types.Channel] = None,
             hyperparameters: Optional[types.Channel] = None,
-            module_file: Optional[
-                Union[Text, data_types.RuntimeParameter]] = None,
             run_fn: Optional[Union[Text, data_types.RuntimeParameter]] = None,
-            trainer_fn: Optional[
-                Union[Text, data_types.RuntimeParameter]] = None,
-            train_args: Union[trainer_pb2.TrainArgs, Dict[Text, Any]] = None,
-            eval_args: Union[trainer_pb2.EvalArgs, Dict[Text, Any]] = None,
             custom_config: Optional[Dict[Text, Any]] = None,
             custom_executor_spec: Optional[executor_spec.ExecutorSpec] = None,
             output: Optional[types.Channel] = None,
@@ -75,15 +74,9 @@ class Trainer(base_component.BaseComponent):
             test_results: Optional[types.Channel] = None,
             instance_name: Optional[Text] = None):
 
-        if [bool(module_file), bool(run_fn), bool(trainer_fn)].count(
-                True) != 1:
-            raise ValueError(
-                "Exactly one of 'module_file', 'trainer_fn', or 'run_fn' must be "
-                "supplied.")
-
         if bool(examples) == bool(transformed_examples):
-            raise ValueError(
-                "Exactly one of 'example' or 'transformed_example' must be supplied.")
+            raise ValueError("Exactly one of 'example' or "
+                             "'transformed_example' must be supplied.")
 
         if transformed_examples and not transform_graph:
             raise ValueError("If 'transformed_examples' is supplied, "
@@ -93,22 +86,18 @@ class Trainer(base_component.BaseComponent):
         output = output or types.Channel(type=Model)
         model_run = model_run or types.Channel(type=ModelRun)
         test_results = test_results or types.Channel(type=Examples)
-        spec = ZenMLTrainerSpec(
-            examples=examples,
-            transform_graph=transform_graph,
-            schema=schema,
-            base_model=base_model,
-            hyperparameters=hyperparameters,
-            train_args=train_args,
-            eval_args=eval_args,
-            module_file=module_file,
-            run_fn=run_fn,
-            trainer_fn=trainer_fn,
-            custom_config=json_utils.dumps(custom_config),
-            model=output,
-            model_run=model_run,
-            test_results=test_results)
-        super(Trainer, self).__init__(
-            spec=spec,
-            custom_executor_spec=custom_executor_spec,
-            instance_name=instance_name)
+
+        spec = ZenMLTrainerSpec(examples=examples,
+                                transform_graph=transform_graph,
+                                schema=schema,
+                                base_model=base_model,
+                                hyperparameters=hyperparameters,
+                                run_fn=run_fn,
+                                custom_config=json_utils.dumps(custom_config),
+                                model=output,
+                                model_run=model_run,
+                                test_results=test_results)
+
+        super(Trainer, self).__init__(spec=spec,
+                                      custom_executor_spec=custom_executor_spec,
+                                      instance_name=instance_name)

--- a/zenml/components/trainer/constants.py
+++ b/zenml/components/trainer/constants.py
@@ -1,8 +1,5 @@
 # ZenML constants
 TEST_RESULTS = 'test_results'
-TRAIN_SPLITS = 'train_splits'
-TEST_SPLITS = 'test_splits'
-EVAL_SPLITS = 'eval_splits'
 
 # TFX constants
 RUN_FN = 'run_fn'

--- a/zenml/components/trainer/constants.py
+++ b/zenml/components/trainer/constants.py
@@ -1,2 +1,16 @@
+# ZenML constants
 TEST_RESULTS = 'test_results'
+TRAIN_SPLITS = 'train_splits'
+TEST_SPLITS = 'test_splits'
+EVAL_SPLITS = 'eval_splits'
 
+# TFX constants
+RUN_FN = 'run_fn'
+CUSTOM_CONFIG = 'custom_config'
+EXAMPLES = 'examples'
+SCHEMA = 'schema'
+BASE_MODEL = 'base_model'
+TRANSFORM_GRAPH = 'transform_graph'
+HYPERPARAMETERS = 'hyperparameters'
+MODEL = 'model'
+MODEL_RUN = 'model_run'

--- a/zenml/components/trainer/executor.py
+++ b/zenml/components/trainer/executor.py
@@ -76,7 +76,7 @@ class ZenMLTrainerExecutor(GenericExecutor):
         output_patterns = dict()
         for split in splits:
             output_patterns.update({
-                split: io_utils.all_files_pattern(uri) for uri in
+                split: uri for uri in
                 artifact_utils.get_split_uris(output_artifact, split)})
 
         out_path = artifact_utils.get_single_uri(output_dict[constants.MODEL])

--- a/zenml/components/trainer/executor.py
+++ b/zenml/components/trainer/executor.py
@@ -1,11 +1,52 @@
-from typing import Dict, Text, List, Any
+import json
+from typing import Any, Dict, List, Text
+from typing import Callable, Iterator, Optional, NamedTuple
 
+import attr
+import pyarrow as pa
+import tensorflow as tf
+from tensorflow.python.lib.io import file_io
+from tensorflow_metadata.proto.v0 import schema_pb2
 from tfx import types
 from tfx.components.trainer import fn_args_utils
 from tfx.components.trainer.executor import GenericExecutor
+from tfx.components.trainer.fn_args_utils import FnArgs
+from tfx.components.util import tfxio_utils
 from tfx.types import artifact_utils
+from tfx.utils import io_utils
+from tfx.utils import json_utils
+from tfx.utils import path_utils
+from tfx_bsl.tfxio import dataset_options
 
 from zenml.components.trainer import constants
+from zenml.logger import get_logger
+
+logger = get_logger(__name__)
+
+_TELEMETRY_DESCRIPTORS = ['Trainer']
+
+DataAccessor = NamedTuple(
+    'DataAccessor',
+    [('tf_dataset_factory', Callable[
+        [List[Text],
+         dataset_options.TensorFlowDatasetOptions,
+         Optional[schema_pb2.Schema],
+         ], tf.data.Dataset]),
+     ('record_batch_factory', Callable[
+         [List[Text],
+          dataset_options.RecordBatchesOptions,
+          Optional[
+              schema_pb2.Schema],
+          ], Iterator[
+             pa.RecordBatch]])])
+
+
+class ZenMLTrainerArgs(FnArgs):
+    train_files = attr.ib(type=Dict[Text, List[Text]])
+    eval_files = attr.ib(type=Dict[Text, List[Text]])
+    test_files = attr.ib(type=Dict[Text, List[Text]])
+
+    test_results = attr.ib(type=Text, default=None)
 
 
 class ZenMLTrainerExecutor(GenericExecutor):
@@ -14,20 +55,153 @@ class ZenMLTrainerExecutor(GenericExecutor):
     handles an additional output artifact while managing the fn_args
     """
 
-    def _GetFnArgs(self, input_dict: Dict[Text, List[types.Artifact]],
+    def _GetFnArgs(self,
+                   input_dict: Dict[Text, List[types.Artifact]],
                    output_dict: Dict[Text, List[types.Artifact]],
                    exec_properties: Dict[Text, Any]) -> fn_args_utils.FnArgs:
-        results = super(ZenMLTrainerExecutor, self)._GetFnArgs(input_dict,
-                                                               output_dict,
-                                                               exec_properties)
-        # TODO[LOW]: fix the fixed eval split
+
+        result = ZenMLTrainerArgs()
+
+        # INPUTS ##############################################################
+        if input_dict.get(constants.BASE_MODEL):
+            base_model = path_utils.serving_model_path(
+                artifact_utils.get_single_uri(
+                    input_dict[constants.BASE_MODEL]))
+        else:
+            base_model = None
+
+        if input_dict.get(constants.HYPERPARAMETERS):
+            hyperparameters_file = io_utils.get_only_uri_in_dir(
+                artifact_utils.get_single_uri(
+                    input_dict[constants.HYPERPARAMETERS]))
+            hyperparameters_config = json.loads(
+                file_io.read_file_to_string(hyperparameters_file))
+        else:
+            hyperparameters_config = None
+
+        if input_dict.get(constants.TRANSFORM_GRAPH):
+            transform_graph_path = artifact_utils.get_single_uri(
+                input_dict[constants.TRANSFORM_GRAPH])
+        else:
+            transform_graph_path = None
+
+        if input_dict.get(constants.SCHEMA):
+            schema_path = io_utils.get_only_uri_in_dir(
+                artifact_utils.get_single_uri(
+                    input_dict[constants.SCHEMA]))
+        else:
+            schema_path = None
+
+        data_accessor = DataAccessor(
+            tf_dataset_factory=tfxio_utils.get_tf_dataset_factory_from_artifact(
+                input_dict[constants.EXAMPLES],
+                _TELEMETRY_DESCRIPTORS),
+            record_batch_factory=tfxio_utils.get_record_batch_factory_from_artifact(
+                input_dict[constants.EXAMPLES],
+                _TELEMETRY_DESCRIPTORS))
+
+        result.base_model = base_model
+        result.hyperparameters = hyperparameters_config
+        result.schema_path = schema_path
+        result.data_accessor = data_accessor
+        result.transform_graph_path = transform_graph_path
+        result.transform_output = result.transform_graph_path
+
+        # PARAMETERS ##########################################################
+
+        # Load and deserialize custom config from execution properties.
+        # Note that in the component interface the default serialization of custom
+        # config is 'null' instead of '{}'. Therefore we need to default the
+        # json_utils.loads to 'null' then populate it with an empty dict when
+        # needed.
+        custom_config = json_utils.loads(
+            exec_properties.get(constants.CUSTOM_CONFIG, 'null'))
+
+        # Examples artifact
+        input_examples = input_dict[constants.EXAMPLES]
+        splits = artifact_utils.decode_split_names(
+            artifact_utils.get_single_instance(input_examples).split_names)
+
+        # Train files
+        if constants.TRAIN_SPLITS in custom_config:
+            train_splits = custom_config[constants.TRAIN_SPLITS]
+        else:
+            train_splits = ['train']
+            logger.info(f'There are no splits specified for the training, '
+                        f'{train_splits} as the default value.')
+
+        train_files = dict()
+        for split in train_splits:
+            assert split in splits, f'There is no such split as: {split}'
+            train_files.update(
+                {split: io_utils.all_files_pattern(uri) for uri in
+                 artifact_utils.get_split_uris(input_examples, split)})
+
+        # Eval files
+        if constants.EVAL_SPLITS in custom_config:
+            eval_splits = custom_config[constants.EVAL_SPLITS]
+        else:
+            eval_splits = ['eval']
+            logger.info(f'There are no splits specified for the evaluation, '
+                        f'{eval_splits} as the default value.')
+
+        eval_files = dict()
+        for split in eval_splits:
+            assert split in splits, f'There is no such split as: {split}'
+            eval_files.update(
+                {split: io_utils.all_files_pattern(uri) for uri in
+                 artifact_utils.get_split_uris(input_examples, split)})
+
+        # Test files
+        if constants.TEST_SPLITS in custom_config:
+            test_splits = custom_config[constants.TEST_SPLITS]
+        else:
+            if 'test' in splits:
+                test_splits = ['test']
+                logger.info(f'There are no splits specified for the test, but '
+                            f'a "test" split is detected, using {test_splits} '
+                            f'as the default value.')
+
+            else:
+                test_splits = []
+                logger.info(f'There are no splits specified for the test and '
+                            f'there are no detected splits, using '
+                            f'{test_splits} as the default value.')
+
+        test_files = dict()
+        for split in test_splits:
+            assert split in splits, f'There is no such split as: {split}'
+            test_files.update(
+                {split: io_utils.all_files_pattern(uri) for uri in
+                 artifact_utils.get_split_uris(input_examples, split)})
+
+        result.custom_config = custom_config
+        result.train_files = train_files
+        result.eval_files = eval_files
+        result.test_files = test_files
+
+        # OUTPUTS #############################################################
+
         output_artifact = artifact_utils.get_single_instance(
             output_dict[constants.TEST_RESULTS])
         output_artifact.split_names = artifact_utils.encode_split_names(
-            ['eval'])
-        test_results = artifact_utils.get_split_uri(
-            [output_artifact], 'eval')
+            test_splits)
 
-        results.test_results = test_results
+        result_files = {
+            split: artifact_utils.get_split_uri([output_artifact], split)
+            for split in test_splits
+        }
 
-        return results
+        output_path = artifact_utils.get_single_uri(
+            output_dict[constants.MODEL])
+        serving_model_dir = path_utils.serving_model_dir(output_path)
+        eval_model_dir = path_utils.eval_model_dir(output_path)
+        model_run_dir = artifact_utils.get_single_uri(
+            output_dict[constants.MODEL_RUN])
+
+        result.test_results = result_files
+        result.serving_model_dir = serving_model_dir
+        result.eval_model_dir = eval_model_dir
+        result.model_run_dir = model_run_dir
+
+        return result

--- a/zenml/components/trainer/executor.py
+++ b/zenml/components/trainer/executor.py
@@ -1,8 +1,6 @@
-import json
 from typing import Any, Dict, List, Text
 
 import attr
-from tensorflow.python.lib.io import file_io
 from tfx import types
 from tfx.components.trainer import fn_args_utils
 from tfx.components.trainer.executor import GenericExecutor
@@ -21,11 +19,8 @@ _TELEMETRY_DESCRIPTORS = ['Trainer']
 
 
 class ZenMLTrainerArgs(FnArgs):
-    train_files = attr.ib(type=Dict[Text, List[Text]])
-    eval_files = attr.ib(type=Dict[Text, List[Text]])
-    test_files = attr.ib(type=Dict[Text, List[Text]])
-
-    test_results = attr.ib(type=Text, default=None)
+    split_patterns = attr.ib(type=Dict[Text, Text], default=None)
+    test_results_dir = attr.ib(type=Text, default=None)
 
 
 class ZenMLTrainerExecutor(GenericExecutor):
@@ -42,22 +37,6 @@ class ZenMLTrainerExecutor(GenericExecutor):
         result = ZenMLTrainerArgs()
 
         # INPUTS ##############################################################
-        if input_dict.get(constants.BASE_MODEL):
-            base_model = path_utils.serving_model_path(
-                artifact_utils.get_single_uri(
-                    input_dict[constants.BASE_MODEL]))
-        else:
-            base_model = None
-
-        if input_dict.get(constants.HYPERPARAMETERS):
-            hyperparameters_file = io_utils.get_only_uri_in_dir(
-                artifact_utils.get_single_uri(
-                    input_dict[constants.HYPERPARAMETERS]))
-            hyperparameters_config = json.loads(
-                file_io.read_file_to_string(hyperparameters_file))
-        else:
-            hyperparameters_config = None
-
         if input_dict.get(constants.TRANSFORM_GRAPH):
             transform_graph_path = artifact_utils.get_single_uri(
                 input_dict[constants.TRANSFORM_GRAPH])
@@ -71,107 +50,33 @@ class ZenMLTrainerExecutor(GenericExecutor):
         else:
             schema_path = None
 
-        result.base_model = base_model
-        result.hyperparameters = hyperparameters_config
-        result.schema_path = schema_path
-        result.transform_graph_path = transform_graph_path
-        result.transform_output = result.transform_graph_path
-
-        # PARAMETERS ##########################################################
-
-        # Load and deserialize custom config from execution properties.
-        # Note that in the component interface the default serialization of custom
-        # config is 'null' instead of '{}'. Therefore we need to default the
-        # json_utils.loads to 'null' then populate it with an empty dict when
-        # needed.
-        custom_config = json_utils.loads(
-            exec_properties.get(constants.CUSTOM_CONFIG, 'null'))
-
-        # Examples artifact
         input_examples = input_dict[constants.EXAMPLES]
         splits = artifact_utils.decode_split_names(
             artifact_utils.get_single_instance(input_examples).split_names)
 
-        # Train files
-        if constants.TRAIN_SPLITS in custom_config:
-            train_splits = custom_config[constants.TRAIN_SPLITS]
-        else:
-            train_splits = ['train']
-            logger.info(f'There are no splits specified for the training, '
-                        f'{train_splits} as the default value.')
+        split_patterns = dict()
+        for split in splits:
+            split_patterns.update({
+                split: io_utils.all_files_pattern(uri) for uri in
+                artifact_utils.get_split_uris(input_examples, split)})
 
-        train_files = dict()
-        for split in train_splits:
-            assert split in splits, f'There is no such split as: {split}'
-            train_files.update(
-                {split: io_utils.all_files_pattern(uri) for uri in
-                 artifact_utils.get_split_uris(input_examples, split)})
+        result.schema_path = schema_path
+        result.transform_output = transform_graph_path
+        result.split_patterns = split_patterns
 
-        # Eval files
-        if constants.EVAL_SPLITS in custom_config:
-            eval_splits = custom_config[constants.EVAL_SPLITS]
-        else:
-            eval_splits = ['eval']
-            logger.info(f'There are no splits specified for the evaluation, '
-                        f'{eval_splits} as the default value.')
-
-        eval_files = dict()
-        for split in eval_splits:
-            assert split in splits, f'There is no such split as: {split}'
-            eval_files.update(
-                {split: io_utils.all_files_pattern(uri) for uri in
-                 artifact_utils.get_split_uris(input_examples, split)})
-
-        # Test files
-        if constants.TEST_SPLITS in custom_config:
-            test_splits = custom_config[constants.TEST_SPLITS]
-        else:
-            if 'test' in splits:
-                test_splits = ['test']
-                logger.info(f'There are no splits specified for the test, but '
-                            f'a "test" split is detected, using {test_splits} '
-                            f'as the default value.')
-
-            else:
-                test_splits = []
-                logger.info(f'There are no splits specified for the test and '
-                            f'there are no detected splits, using '
-                            f'{test_splits} as the default value.')
-
-        test_files = dict()
-        for split in test_splits:
-            assert split in splits, f'There is no such split as: {split}'
-            test_files.update(
-                {split: io_utils.all_files_pattern(uri) for uri in
-                 artifact_utils.get_split_uris(input_examples, split)})
-
+        # PARAMETERS ##########################################################
+        custom_config = json_utils.loads(
+            exec_properties.get(constants.CUSTOM_CONFIG, 'null'))
         result.custom_config = custom_config
-        result.train_files = train_files
-        result.eval_files = eval_files
-        result.test_files = test_files
 
         # OUTPUTS #############################################################
-
-        output_artifact = artifact_utils.get_single_instance(
+        test_results_dir = artifact_utils.get_single_uri(
             output_dict[constants.TEST_RESULTS])
-        output_artifact.split_names = artifact_utils.encode_split_names(
-            test_splits)
 
-        result_files = {
-            split: artifact_utils.get_split_uri([output_artifact], split)
-            for split in test_splits
-        }
+        out_path = artifact_utils.get_single_uri(output_dict[constants.MODEL])
+        serving_model_dir = path_utils.serving_model_dir(out_path)
 
-        output_path = artifact_utils.get_single_uri(
-            output_dict[constants.MODEL])
-        serving_model_dir = path_utils.serving_model_dir(output_path)
-        eval_model_dir = path_utils.eval_model_dir(output_path)
-        model_run_dir = artifact_utils.get_single_uri(
-            output_dict[constants.MODEL_RUN])
-
-        result.test_results = result_files
+        result.test_results_dir = test_results_dir
         result.serving_model_dir = serving_model_dir
-        result.eval_model_dir = eval_model_dir
-        result.model_run_dir = model_run_dir
 
         return result

--- a/zenml/components/trainer/executor.py
+++ b/zenml/components/trainer/executor.py
@@ -1,22 +1,16 @@
 import json
 from typing import Any, Dict, List, Text
-from typing import Callable, Iterator, Optional, NamedTuple
 
 import attr
-import pyarrow as pa
-import tensorflow as tf
 from tensorflow.python.lib.io import file_io
-from tensorflow_metadata.proto.v0 import schema_pb2
 from tfx import types
 from tfx.components.trainer import fn_args_utils
 from tfx.components.trainer.executor import GenericExecutor
 from tfx.components.trainer.fn_args_utils import FnArgs
-from tfx.components.util import tfxio_utils
 from tfx.types import artifact_utils
 from tfx.utils import io_utils
 from tfx.utils import json_utils
 from tfx.utils import path_utils
-from tfx_bsl.tfxio import dataset_options
 
 from zenml.components.trainer import constants
 from zenml.logger import get_logger
@@ -24,21 +18,6 @@ from zenml.logger import get_logger
 logger = get_logger(__name__)
 
 _TELEMETRY_DESCRIPTORS = ['Trainer']
-
-DataAccessor = NamedTuple(
-    'DataAccessor',
-    [('tf_dataset_factory', Callable[
-        [List[Text],
-         dataset_options.TensorFlowDatasetOptions,
-         Optional[schema_pb2.Schema],
-         ], tf.data.Dataset]),
-     ('record_batch_factory', Callable[
-         [List[Text],
-          dataset_options.RecordBatchesOptions,
-          Optional[
-              schema_pb2.Schema],
-          ], Iterator[
-             pa.RecordBatch]])])
 
 
 class ZenMLTrainerArgs(FnArgs):
@@ -92,18 +71,9 @@ class ZenMLTrainerExecutor(GenericExecutor):
         else:
             schema_path = None
 
-        data_accessor = DataAccessor(
-            tf_dataset_factory=tfxio_utils.get_tf_dataset_factory_from_artifact(
-                input_dict[constants.EXAMPLES],
-                _TELEMETRY_DESCRIPTORS),
-            record_batch_factory=tfxio_utils.get_record_batch_factory_from_artifact(
-                input_dict[constants.EXAMPLES],
-                _TELEMETRY_DESCRIPTORS))
-
         result.base_model = base_model
         result.hyperparameters = hyperparameters_config
         result.schema_path = schema_path
-        result.data_accessor = data_accessor
         result.transform_graph_path = transform_graph_path
         result.transform_output = result.transform_graph_path
 

--- a/zenml/components/trainer/trainer_module.py
+++ b/zenml/components/trainer/trainer_module.py
@@ -19,15 +19,13 @@ from zenml.utils.source_utils import load_source_path_class
 def run_fn(fn_args):
     fn_args_dict = fn_args.__dict__
     custom_config = fn_args_dict.pop('custom_config')
-    c = load_source_path_class(custom_config.pop(StepKeys.SOURCE))
 
-    # Pop unnecessary args
+    # Get the user defined args
     args = custom_config.pop(StepKeys.ARGS)
-
-    # TODO: [LOW] Hard-coded
-    fn_args_dict.pop('data_accessor')
 
     # We update users args first, because fn_args might have overlaps
     args.update(fn_args_dict)
 
+    # Load the step, parameterize it and run it
+    c = load_source_path_class(custom_config.pop(StepKeys.SOURCE))
     return c(**args).run_fn()

--- a/zenml/pipelines/training_pipeline.py
+++ b/zenml/pipelines/training_pipeline.py
@@ -192,8 +192,6 @@ class TrainingPipeline(BasePipeline):
             transform_graph=transform.outputs.transform_graph,
             run_fn=constants.TRAINER_FN,
             schema=schema,
-            train_args=trainer_pb2.TrainArgs(),
-            eval_args=trainer_pb2.EvalArgs(),
             **training_kwargs
         ).with_id(GDPComponent.Trainer.name)
 

--- a/zenml/pipelines/training_pipeline.py
+++ b/zenml/pipelines/training_pipeline.py
@@ -23,12 +23,10 @@ from tfx.components.pusher.component import Pusher
 from tfx.components.schema_gen.component import SchemaGen
 from tfx.components.statistics_gen.component import StatisticsGen
 from tfx.components.transform.component import Transform
-from tfx.proto import trainer_pb2
 
 from zenml import constants
 from zenml.backends.training import TrainingBaseBackend
 from zenml.components import DataGen, Sequencer, SplitGen, Trainer, Evaluator
-
 from zenml.enums import GDPComponent
 from zenml.exceptions import DoesNotExistException, \
     PipelineNotSucceededException
@@ -38,6 +36,7 @@ from zenml.standards import standard_keys as keys
 from zenml.steps.deployer import BaseDeployerStep
 from zenml.steps.evaluator import BaseEvaluatorStep
 from zenml.steps.preprocesser import BasePreprocesserStep
+from zenml.steps.preprocesser.base_preprocesser import build_split_mapping
 from zenml.steps.sequencer import BaseSequencerStep
 from zenml.steps.split import BaseSplit
 from zenml.steps.trainer import BaseTrainerStep
@@ -161,10 +160,14 @@ class TrainingPipeline(BasePipeline):
         #################
         # PREPROCESSING #
         #################
+        split_mapping = build_split_mapping(
+            steps[keys.TrainingSteps.PREPROCESSER][keys.StepKeys.ARGS])
+
         transform = Transform(
             preprocessing_fn=constants.PREPROCESSING_FN,
             examples=datapoints,
             schema=schema,
+            splits_config=split_mapping,
             custom_config=steps[keys.TrainingSteps.PREPROCESSER]
         ).with_id(GDPComponent.Transform.name)
 
@@ -219,8 +222,9 @@ class TrainingPipeline(BasePipeline):
                     model=trainer.outputs.model,
                 ).with_id(GDPComponent.Evaluator.name)
             else:
-                raise ValueError('Please use either the built-in TFMAEvaluator '
-                                 'or the AgnosticEvaluator')
+                raise ValueError(
+                    'Please use either the built-in TFMAEvaluator '
+                    'or the AgnosticEvaluator')
             component_list.append(evaluator)
 
         ###########

--- a/zenml/steps/evaluator/agnostic_evaluator.py
+++ b/zenml/steps/evaluator/agnostic_evaluator.py
@@ -46,7 +46,8 @@ class AgnosticEvaluator(BaseEvaluatorStep):
                  label_key: Text,
                  prediction_key: Text,
                  slices: List[List[Text]] = None,
-                 metrics: List[Text] = None):
+                 metrics: List[Text] = None,
+                 splits: List[Text] = None):
         """
         Init for the AgnosticEvaluator
 
@@ -57,14 +58,17 @@ class AgnosticEvaluator(BaseEvaluatorStep):
         :param slices: a list of lists, each element in the inner list include
         a set of features which will be used for slicing on the results
         :param metrics: list of metrics to be computed
+        :param splits: the list of splits to apply the evaluation on
         """
         super().__init__(label_key=label_key,
                          prediction_key=prediction_key,
                          slices=slices,
-                         metrics=metrics)
+                         metrics=metrics,
+                         splits=splits)
 
         self.slices = slices or list()
         self.metrics = metrics or list()
+        self.splits = splits or ['eval']
 
         self.prediction_key = prediction_key
         self.label_key = label_key

--- a/zenml/steps/evaluator/agnostic_evaluator.py
+++ b/zenml/steps/evaluator/agnostic_evaluator.py
@@ -47,7 +47,7 @@ class AgnosticEvaluator(BaseEvaluatorStep):
                  prediction_key: Text,
                  slices: List[List[Text]] = None,
                  metrics: List[Text] = None,
-                 splits: List[Text] = None):
+                 **kwargs):
         """
         Init for the AgnosticEvaluator
 
@@ -60,15 +60,14 @@ class AgnosticEvaluator(BaseEvaluatorStep):
         :param metrics: list of metrics to be computed
         :param splits: the list of splits to apply the evaluation on
         """
-        super().__init__(label_key=label_key,
-                         prediction_key=prediction_key,
-                         slices=slices,
-                         metrics=metrics,
-                         splits=splits)
+        super(AgnosticEvaluator, self).__init__(label_key=label_key,
+                                                prediction_key=prediction_key,
+                                                slices=slices,
+                                                metrics=metrics,
+                                                **kwargs)
 
         self.slices = slices or list()
         self.metrics = metrics or list()
-        self.splits = splits or ['eval']
 
         self.prediction_key = prediction_key
         self.label_key = label_key

--- a/zenml/steps/evaluator/agnostic_evaluator.py
+++ b/zenml/steps/evaluator/agnostic_evaluator.py
@@ -46,8 +46,7 @@ class AgnosticEvaluator(BaseEvaluatorStep):
                  label_key: Text,
                  prediction_key: Text,
                  slices: List[List[Text]] = None,
-                 metrics: List[Text] = None,
-                 splits: List[Text] = None):
+                 metrics: List[Text] = None):
         """
         Init for the AgnosticEvaluator
 
@@ -58,17 +57,14 @@ class AgnosticEvaluator(BaseEvaluatorStep):
         :param slices: a list of lists, each element in the inner list include
         a set of features which will be used for slicing on the results
         :param metrics: list of metrics to be computed
-        :param splits: the list of splits to apply the evaluation on
         """
         super().__init__(label_key=label_key,
                          prediction_key=prediction_key,
                          slices=slices,
-                         metrics=metrics,
-                         splits=splits)
+                         metrics=metrics)
 
         self.slices = slices or list()
         self.metrics = metrics or list()
-        self.splits = splits or ['eval']
 
         self.prediction_key = prediction_key
         self.label_key = label_key

--- a/zenml/steps/evaluator/base_evaluator.py
+++ b/zenml/steps/evaluator/base_evaluator.py
@@ -13,8 +13,10 @@
 #  permissions and limitations under the License.
 
 
-from zenml.steps import BaseStep
+from typing import Dict, List, Text
+
 from zenml.enums import StepTypes
+from zenml.steps import BaseStep
 
 
 class BaseEvaluatorStep(BaseStep):
@@ -24,6 +26,13 @@ class BaseEvaluatorStep(BaseStep):
     CUSTOM_MODULE = None
 
     STEP_TYPE = StepTypes.evaluator.name
+
+    def __init__(self,
+                 split_mapping: Dict[Text, List[Text]] = None,
+                 **kwargs):
+        self.split_mapping = split_mapping
+        super(BaseEvaluatorStep, self).__init__(split_mapping=split_mapping,
+                                                **kwargs)
 
     def build_config(self):
         pass

--- a/zenml/steps/evaluator/tfma_evaluator.py
+++ b/zenml/steps/evaluator/tfma_evaluator.py
@@ -43,7 +43,7 @@ class TFMAEvaluator(BaseEvaluatorStep):
                  metrics: Dict[Text, List[Text]],
                  slices: List[List[Text]] = None,
                  output_mapping: Dict[Text, Text] = None,
-                 splits: List[Text] = None):
+                 **kwargs):
         """
         Init for the TFMA evaluator
 
@@ -57,15 +57,13 @@ class TFMAEvaluator(BaseEvaluatorStep):
         :param splits: the list of splits to apply the evaluation on
         """
 
-        super().__init__(slices=slices,
-                         metrics=metrics,
-                         splits=splits,
-                         output_mapping=output_mapping)
+        super(TFMAEvaluator, self).__init__(slices=slices,
+                                            metrics=metrics,
+                                            output_mapping=output_mapping,
+                                            **kwargs)
 
         self.metrics = metrics
-
         self.slices = slices or list()
-        self.splits = splits or ['eval']
 
         if output_mapping is None:
             if len(self.metrics.keys()) == 1:

--- a/zenml/steps/preprocesser/base_preprocesser.py
+++ b/zenml/steps/preprocesser/base_preprocesser.py
@@ -23,7 +23,7 @@ SPLIT_MAPPING = 'split_mapping'
 
 
 def build_split_mapping(args):
-    if SPLIT_MAPPING in args:
+    if SPLIT_MAPPING in args and args[SPLIT_MAPPING]:
         splits_config = transform_pb2.SplitsConfig()
         for process, splits in args[SPLIT_MAPPING].items():
             for split in splits:

--- a/zenml/steps/preprocesser/base_preprocesser.py
+++ b/zenml/steps/preprocesser/base_preprocesser.py
@@ -26,6 +26,9 @@ SPLIT_MAPPING = 'split_mapping'
 def build_split_mapping(args):
     if SPLIT_MAPPING in args and args[SPLIT_MAPPING]:
         splits_config = transform_pb2.SplitsConfig()
+        assert TRAIN_SPLITS in args[SPLIT_MAPPING], \
+            f'When you are defining a custom split mapping, please define ' \
+            f'{TRAIN_SPLITS}!'
         for process, splits in args[SPLIT_MAPPING].items():
             for split in splits:
                 if process == TRAIN_SPLITS:

--- a/zenml/steps/preprocesser/base_preprocesser.py
+++ b/zenml/steps/preprocesser/base_preprocesser.py
@@ -18,6 +18,7 @@ from tfx.proto import transform_pb2
 
 from zenml.enums import StepTypes
 from zenml.steps import BaseStep
+from zenml.steps.trainer.utils import TRAIN_SPLITS
 
 SPLIT_MAPPING = 'split_mapping'
 
@@ -27,7 +28,7 @@ def build_split_mapping(args):
         splits_config = transform_pb2.SplitsConfig()
         for process, splits in args[SPLIT_MAPPING].items():
             for split in splits:
-                if process == 'train':
+                if process == TRAIN_SPLITS:
                     splits_config.analyze.append(split)
                 splits_config.transform.append(split)
         return splits_config

--- a/zenml/steps/preprocesser/standard_preprocesser/standard_preprocesser.py
+++ b/zenml/steps/preprocesser/standard_preprocesser/standard_preprocesser.py
@@ -90,7 +90,10 @@ class StandardPreprocesser(BasePreprocesserStep):
             **unused_kwargs: Additional unused keyword arguments. Their usage
              might change in the future.
         """
-        super().__init__(features=features, labels=labels, overwrite=overwrite)
+        super(StandardPreprocesser, self).__init__(features=features,
+                                                   labels=labels,
+                                                   overwrite=overwrite,
+                                                   **unused_kwargs)
 
         # List of features and labels
         self.features = features or []

--- a/zenml/steps/split/categorical_domain_split_step.py
+++ b/zenml/steps/split/categorical_domain_split_step.py
@@ -24,9 +24,6 @@ CategoricalValue = Union[Text, int]
 
 def lint_split_map(split_map: Dict[Text, List[CategoricalValue]]):
     """Small utility to lint the split_map"""
-    if constants.TRAIN not in split_map.keys():
-        raise AssertionError(f'You have to define some values for '
-                             f'the {constants.TRAIN} split.')
     if len(split_map) <= 1:
         raise AssertionError('Please specify more than 1 split name in the '
                              'split_map!')

--- a/zenml/steps/split/categorical_ratio_split_step.py
+++ b/zenml/steps/split/categorical_ratio_split_step.py
@@ -26,9 +26,6 @@ CategoricalValue = Union[Text, int]
 
 def lint_split_map(split_map: Dict[Text, float]):
     """Small utility to lint the split_map"""
-    if constants.TRAIN not in split_map.keys():
-        raise AssertionError(f'You have to define some values for '
-                             f'the {constants.TRAIN} split.')
     if len(split_map) <= 1:
         raise AssertionError('Please specify more than 1 split name in the '
                              'split_map!')

--- a/zenml/steps/split/random_split.py
+++ b/zenml/steps/split/random_split.py
@@ -18,15 +18,12 @@ from typing import Text, List, Dict, Any
 
 import numpy as np
 
-from zenml.steps.split import constants
 from zenml.steps.split import BaseSplit
 
 
 def lint_split_map(split_map: Dict[Text, float]):
     """Small utility to lint the split_map"""
-    if constants.TRAIN not in split_map.keys():
-        raise AssertionError(f'You have to define some values for '
-                             f'the {constants.TRAIN} split.')
+    # TODO[MEDIUM]: Currently, it does not fail when the sum is more than 1
     if len(split_map) <= 1:
         raise AssertionError('Please specify more than 1 split name in the '
                              'split_map!')

--- a/zenml/steps/trainer/base_trainer.py
+++ b/zenml/steps/trainer/base_trainer.py
@@ -67,9 +67,7 @@ class BaseTrainerStep(BaseStep):
         if self.transform_output is not None:
             self.tf_transform_output = tft.TFTransformOutput(
                 self.transform_output)
-            self.schema = self.tf_transform_output.transformed_feature_spec(
-
-            ).copy()
+            self.schema = self.tf_transform_output.transformed_feature_spec().copy()
 
         if self.serving_model_dir is not None:
             self.log_dir = os.path.join(
@@ -95,8 +93,7 @@ class BaseTrainerStep(BaseStep):
         pass
 
     @staticmethod
-    def model_fn(train_dataset,
-                 eval_dataset):
+    def model_fn(train_dataset, eval_dataset):
         """
         Method defining the training flow of the model. Override this
         in subclasses to define your own custom training flow.

--- a/zenml/steps/trainer/base_trainer.py
+++ b/zenml/steps/trainer/base_trainer.py
@@ -30,10 +30,10 @@ class BaseTrainerStep(BaseStep):
     STEP_TYPE = StepTypes.trainer.name
 
     def __init__(self,
-                 split_patterns: Dict[Text, Text] = None,
+                 input_patterns: Dict[Text, Text] = None,
+                 output_patterns: Dict[Text, Text] = None,
                  serving_model_dir: Text = None,
                  transform_output: Text = None,
-                 test_results_dir: Text = None,
                  split_mapping: Dict[Text, List[Text]] = None,
                  **kwargs):
         """
@@ -54,7 +54,7 @@ class BaseTrainerStep(BaseStep):
             schema: Schema file from a preceding SchemaGen.
         """
         # Inputs
-        self.split_patterns = split_patterns
+        self.input_patterns = input_patterns
         self.schema = None
         self.tf_transform_output = None
 
@@ -66,8 +66,8 @@ class BaseTrainerStep(BaseStep):
         self.split_mapping = split_mapping
 
         # Outputs
+        self.output_patterns = output_patterns
         self.serving_model_dir = serving_model_dir
-        self.test_results_dir = test_results_dir
         self.log_dir = None
 
         if self.serving_model_dir is not None:

--- a/zenml/steps/trainer/base_trainer.py
+++ b/zenml/steps/trainer/base_trainer.py
@@ -63,14 +63,7 @@ class BaseTrainerStep(BaseStep):
             self.schema = self.tf_transform_output.transformed_feature_spec()
 
         # Parameters
-        if split_mapping is None:
-            self.split_mapping = {'train': ['train'],
-                                  'eval': ['eval'],
-                                  'test': []}
-            if self.split_patterns and 'test' in self.split_patterns:
-                self.split_mapping = {'test': ['test']}
-        else:
-            self.split_mapping = split_mapping
+        self.split_mapping = split_mapping
 
         # Outputs
         self.serving_model_dir = serving_model_dir

--- a/zenml/steps/trainer/base_trainer.py
+++ b/zenml/steps/trainer/base_trainer.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 
 import os
-from typing import List, Text
+from typing import Dict, List, Text
 
 import tensorflow_transform as tft
 
@@ -30,12 +30,10 @@ class BaseTrainerStep(BaseStep):
     STEP_TYPE = StepTypes.trainer.name
 
     def __init__(self,
+                 split_patterns: Dict[Text, Text] = None,
                  serving_model_dir: Text = None,
                  transform_output: Text = None,
-                 test_results: Text = None,
-                 train_files=None,
-                 eval_files=None,
-                 test_files=None,
+                 test_results_dir: Text = None,
                  **kwargs):
         """
         Constructor for the BaseTrainerStep. All subclasses used for custom
@@ -55,21 +53,19 @@ class BaseTrainerStep(BaseStep):
             schema: Schema file from a preceding SchemaGen.
         """
         super().__init__(**kwargs)
-        self.serving_model_dir = serving_model_dir
-        self.transform_output = transform_output
-        self.test_results = test_results
-        self.train_files = train_files
-        self.eval_files = eval_files
-        self.test_files = test_files
+        # Inputs
+        self.split_patterns = split_patterns
         self.schema = None
-        self.log_dir = None
         self.tf_transform_output = None
 
-        # Infer schema and log_dir
-        if self.transform_output is not None:
-            self.tf_transform_output = tft.TFTransformOutput(
-                self.transform_output)
-            self.schema = self.tf_transform_output.transformed_feature_spec().copy()
+        if transform_output is not None:
+            self.tf_transform_output = tft.TFTransformOutput(transform_output)
+            self.schema = self.tf_transform_output.transformed_feature_spec()
+
+        # Outputs
+        self.serving_model_dir = serving_model_dir
+        self.test_results_dir = test_results_dir
+        self.log_dir = None
 
         if self.serving_model_dir is not None:
             self.log_dir = os.path.join(

--- a/zenml/steps/trainer/base_trainer.py
+++ b/zenml/steps/trainer/base_trainer.py
@@ -35,6 +35,7 @@ class BaseTrainerStep(BaseStep):
                  test_results: Text = None,
                  train_files=None,
                  eval_files=None,
+                 test_files=None,
                  **kwargs):
         """
         Constructor for the BaseTrainerStep. All subclasses used for custom
@@ -59,6 +60,7 @@ class BaseTrainerStep(BaseStep):
         self.test_results = test_results
         self.train_files = train_files
         self.eval_files = eval_files
+        self.test_files = test_files
         self.schema = None
         self.log_dir = None
         self.tf_transform_output = None

--- a/zenml/steps/trainer/pytorch_trainers/torch_ff_trainer.py
+++ b/zenml/steps/trainer/pytorch_trainers/torch_ff_trainer.py
@@ -78,7 +78,6 @@ class FeedForwardTrainer(TorchBaseTrainerStep):
                  last_activation: str = 'sigmoid',
                  input_units: int = 8,
                  output_units: int = 1,
-                 split_mapping: Dict[Text, List[Text]] = None,
                  **kwargs):
         self.batch_size = batch_size
         self.lr = lr
@@ -92,15 +91,6 @@ class FeedForwardTrainer(TorchBaseTrainerStep):
         self.input_units = input_units
         self.output_units = output_units
 
-        if split_mapping is None:
-            self.split_mapping = {'train': ['train'],
-                                  'eval': ['eval'],
-                                  'test': []}
-            if self.split_patterns and 'test' in self.split_patterns:
-                self.split_mapping = {'test': ['test']}
-        else:
-            self.split_mapping = split_mapping
-
         super(FeedForwardTrainer, self).__init__(
             batch_size=self.batch_size,
             lr=self.lr,
@@ -113,7 +103,6 @@ class FeedForwardTrainer(TorchBaseTrainerStep):
             last_activation=self.last_activation,
             input_units=self.input_units,
             output_units=self.output_units,
-            split_mapping=self.split_mapping,
             **kwargs)
 
     def input_fn(self,

--- a/zenml/steps/trainer/pytorch_trainers/torch_ff_trainer.py
+++ b/zenml/steps/trainer/pytorch_trainers/torch_ff_trainer.py
@@ -106,11 +106,10 @@ class FeedForwardTrainer(TorchBaseTrainerStep):
             **kwargs)
 
     def input_fn(self,
-                 file_patterns: List[Text],
-                 transformed_spec: Dict[Text, Text]):
+                 file_patterns: List[Text]):
 
         dataset = torch_utils.TFRecordTorchDataset(file_patterns,
-                                                   transformed_spec)
+                                                   self.schema)
         loader = torch.utils.data.DataLoader(dataset,
                                              batch_size=self.batch_size,
                                              drop_last=True)
@@ -156,11 +155,11 @@ class FeedForwardTrainer(TorchBaseTrainerStep):
     def run_fn(self):
         train_split_patterns = [self.split_patterns[split]
                                 for split in self.split_mapping['train']]
-        train_dataset = self.input_fn(train_split_patterns, self.schema)
+        train_dataset = self.input_fn(train_split_patterns)
 
         eval_split_patterns = [self.split_patterns[split]
                                for split in self.split_mapping['eval']]
-        eval_dataset = self.input_fn(eval_split_patterns, self.schema)
+        eval_dataset = self.input_fn(eval_split_patterns)
 
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         model = self.model_fn(train_dataset, eval_dataset)
@@ -212,7 +211,7 @@ class FeedForwardTrainer(TorchBaseTrainerStep):
         test_split_patterns = [self.split_patterns[split]
                                for split in self.split_mapping['test']]
         if test_split_patterns:
-            test_dataset = self.input_fn(test_split_patterns, self.schema)
+            test_dataset = self.input_fn(test_split_patterns)
             test_results = self.test_fn(model, test_dataset)
             utils.save_test_results(test_results, self.test_results_dir)
 

--- a/zenml/steps/trainer/tensorflow_trainers/tf_ff_trainer.py
+++ b/zenml/steps/trainer/tensorflow_trainers/tf_ff_trainer.py
@@ -16,7 +16,6 @@
 from typing import List, Text
 
 import tensorflow as tf
-import tensorflow_transform as tft
 
 from zenml.steps.trainer import TFBaseTrainerStep
 from zenml.steps.trainer import utils
@@ -89,9 +88,9 @@ class FeedForwardTrainer(TFBaseTrainerStep):
             **kwargs
         )
 
-    def test_fn(self, model, datasets):
+    def test_fn(self, model, dataset):
         batch_list = []
-        for x, y in datasets:
+        for x, y in dataset:
             # start with an empty batch
             batch = {}
 
@@ -125,29 +124,36 @@ class FeedForwardTrainer(TFBaseTrainerStep):
         return combined_batch
 
     def run_fn(self):
-        tf_transform_output = tft.TFTransformOutput(self.transform_output)
+        train_split_patterns = [self.split_patterns[split]
+                                for split in self.split_mapping['train']]
+        train_dataset = self.input_fn(train_split_patterns)
 
-        train_dataset = self.input_fn(self.train_files, tf_transform_output)
-        eval_dataset = self.input_fn(self.eval_files, tf_transform_output)
+        eval_split_patterns = [self.split_patterns[split]
+                               for split in self.split_mapping['eval']]
+        eval_dataset = self.input_fn(eval_split_patterns)
 
         model = self.model_fn(train_dataset=train_dataset,
                               eval_dataset=eval_dataset)
 
-        test_results = self.test_fn(model, eval_dataset)
-        utils.save_test_results(test_results, self.test_results)
+        test_split_patterns = [self.split_patterns[split]
+                               for split in self.split_mapping['test']]
+        if test_split_patterns:
+            test_dataset = self.input_fn(test_split_patterns)
+            test_results = self.test_fn(model, test_dataset)
+            utils.save_test_results(test_results, self.test_results_dir)
 
         signatures = {
             'serving_default':
                 self._get_serve_tf_examples_fn(
                     model,
-                    tf_transform_output
+                    self.tf_transform_output
                 ).get_concrete_function(tf.TensorSpec(shape=[None],
                                                       dtype=tf.string,
                                                       name='examples')),
             'zen_eval':
                 self._get_zen_eval_tf_examples_fn(
                     model,
-                    tf_transform_output
+                    self.tf_transform_output
                 ).get_concrete_function(tf.TensorSpec(shape=[None],
                                                       dtype=tf.string,
                                                       name='examples'))}
@@ -157,27 +163,21 @@ class FeedForwardTrainer(TFBaseTrainerStep):
                    signatures=signatures)
 
     def input_fn(self,
-                 file_pattern: List[Text],
-                 tf_transform_output: tft.TFTransformOutput):
+                 file_pattern: List[Text]):
         """
         Feedforward input_fn for loading data from TFRecords saved to a
         location on disk.
 
         Args:
             file_pattern: File pattern matching saved TFRecords on disk.
-            tf_transform_output: Output of the preceding Transform /
-             Preprocessing component.
 
         Returns:
             dataset: tf.data.Dataset created out of the input files.
         """
-
-        xf_feature_spec = tf_transform_output.transformed_feature_spec()
-
         dataset = tf.data.experimental.make_batched_features_dataset(
             file_pattern=file_pattern,
             batch_size=self.batch_size,
-            features=xf_feature_spec,
+            features=self.schema,
             reader=self._gzip_reader_fn,
             num_epochs=1,
             drop_final_batch=True)
@@ -288,7 +288,8 @@ class FeedForwardTrainer(TFBaseTrainerStep):
         labels = list(train_dataset.element_spec[1].keys())
 
         input_layers = [tf.keras.layers.Input(shape=(1,), name=k)
-                        for k in features if naming_utils.check_if_transformed_feature(k)]
+                        for k in features if
+                        naming_utils.check_if_transformed_feature(k)]
 
         d = tf.keras.layers.Concatenate()(input_layers)
 

--- a/zenml/steps/trainer/tensorflow_trainers/tf_ff_trainer.py
+++ b/zenml/steps/trainer/tensorflow_trainers/tf_ff_trainer.py
@@ -124,23 +124,28 @@ class FeedForwardTrainer(TFBaseTrainerStep):
         return combined_batch
 
     def run_fn(self):
-        train_split_patterns = [self.split_patterns[split]
-                                for split in self.split_mapping['train']]
+        split_mapping = utils.fill_split_mapping_w_defaults(
+            mapping=self.split_mapping,
+            splits=list(self.input_patterns.keys()))
+
+        train_split_patterns = [self.input_patterns[split]
+                                for split in split_mapping[utils.TRAIN_SPLITS]]
         train_dataset = self.input_fn(train_split_patterns)
 
-        eval_split_patterns = [self.split_patterns[split]
-                               for split in self.split_mapping['eval']]
+        eval_split_patterns = [self.input_patterns[split]
+                               for split in split_mapping[utils.EVAL_SPLITS]]
         eval_dataset = self.input_fn(eval_split_patterns)
 
         model = self.model_fn(train_dataset=train_dataset,
                               eval_dataset=eval_dataset)
 
-        test_split_patterns = [self.split_patterns[split]
-                               for split in self.split_mapping['test']]
-        if test_split_patterns:
-            test_dataset = self.input_fn(test_split_patterns)
-            test_results = self.test_fn(model, test_dataset)
-            utils.save_test_results(test_results, self.test_results_dir)
+        if split_mapping[utils.TEST_SPLITS]:
+            for split in split_mapping[utils.TEST_SPLITS]:
+                pattern = self.input_patterns[split]
+                test_dataset = self.input_fn([pattern])
+                test_results = self.test_fn(model, test_dataset)
+                utils.save_test_results(test_results,
+                                        self.output_patterns[split])
 
         signatures = {
             'serving_default':

--- a/zenml/steps/trainer/utils.py
+++ b/zenml/steps/trainer/utils.py
@@ -7,6 +7,32 @@ import torch
 
 from zenml.utils import path_utils
 
+SPLIT_MAPPING = 'split_mapping'
+
+TRAIN_SPLITS = 'train_splits'
+EVAL_SPLITS = 'eval_splits'
+TEST_SPLITS = 'test_splits'
+
+
+def fill_split_mapping_w_defaults(mapping=None, splits=None):
+    if mapping:
+        assert len(mapping[TRAIN_SPLITS]) > 0, \
+            'While defining your own mapping, you need to provide at least ' \
+            'one training split.'
+        assert len(mapping[EVAL_SPLITS]) > 0, \
+            'While defining your own mapping, you need to provide at least ' \
+            'one eval split.'
+        # TODO [LOW]: As a utility function, we can check whether any of the
+        #   test splits leaked into train or eval
+        return mapping
+    else:
+        mapping = {TRAIN_SPLITS: ['train'],
+                   EVAL_SPLITS: ['eval'],
+                   TEST_SPLITS: []}
+        if splits is not None and 'test' in splits:
+            mapping.update({TEST_SPLITS: ['test']})
+        return mapping
+
 
 def save_test_results(results, output_path):
     path_utils.create_dir_if_not_exists(output_path)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **CONTRIBUTING.md** document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Here is the first draft of the new split configuration created for the training pipeline. A user now can create a `split_mapping` while defining the training pipeline and use it to specify which splits will be used for training, testing and evaluation respectively throughout the transform, train and eval steps.

List of changes:
- The inner-workings of the `base_trainer_step`, `base_evaluator_step` and the `base_preprocesser_step` have been modified along with their respective components to work with the new `split_mapping`.
- Most importantly, within the instance of a `base_trainer_step`, you have access to `input_patterns` and `output_patterns` which provide you the required uris with respect to their splits for the input and output(test_results) examples. 
- The built-in trainers are already modified to work with the new changes, **however** the examples are not updated yet.