### PR TITLE
Baris/hotfix

### DIFF
--- a/examples/quickstart/quickstart.ipynb
+++ b/examples/quickstart/quickstart.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_pipeline.add_split(RandomSplit(split_map={'train': 0.7, 'eval': 0.3}))"
+    "training_pipeline.add_split(RandomSplit(split_map={'train': 0.7, 'eval': 0.2, 'test':0.1}))"
    ]
   },
   {

--- a/zenml/steps/split/categorical_ratio_split_step.py
+++ b/zenml/steps/split/categorical_ratio_split_step.py
@@ -30,10 +30,6 @@ def lint_split_map(split_map: Dict[Text, float]):
         raise AssertionError('Please specify more than 1 split name in the '
                              'split_map!')
 
-    if not all(isinstance(v, (int, float)) for v in split_map.values()):
-        raise AssertionError("Only int or float values are allowed when "
-                             "specifying a random split!")
-
 
 class CategoricalRatioSplit(BaseSplit):
     """

--- a/zenml/steps/split/categorical_ratio_split_step.py
+++ b/zenml/steps/split/categorical_ratio_split_step.py
@@ -30,6 +30,10 @@ def lint_split_map(split_map: Dict[Text, float]):
         raise AssertionError('Please specify more than 1 split name in the '
                              'split_map!')
 
+    if not all(isinstance(v, (int, float)) for v in split_map.values()):
+        raise AssertionError("Only int or float values are allowed when "
+                             "specifying a random split!")
+
 
 class CategoricalRatioSplit(BaseSplit):
     """
@@ -94,8 +98,8 @@ class CategoricalRatioSplit(BaseSplit):
              splitting.
             categories: List of categorical values found in the categorical
              column on which to split.
-            split_ratio: A dict mapping { split_name: percentage of categories
-                                    in split }.
+            split_ratio: A dict mapping { split_name: ratio of categories
+             in split }.
             unknown_category_policy: String, indicates how to handle categories
              in the data that are not present in the supplied category list.
         """

--- a/zenml/steps/split/random_split.py
+++ b/zenml/steps/split/random_split.py
@@ -54,7 +54,7 @@ def RandomSplitPartitionFn(element: Any,
     probability_mass = np.cumsum(list(split_map.values()))
     max_value = probability_mass[-1]
 
-    return bisect.bisect(probability_mass, np.random.rand(0, max_value))
+    return bisect.bisect(probability_mass, np.random.uniform(0, max_value))
 
 
 class RandomSplit(BaseSplit):

--- a/zenml/steps/split/utils.py
+++ b/zenml/steps/split/utils.py
@@ -63,8 +63,8 @@ def partition_cat_list(cat_list: List[CategoricalValue],
 
     Args:
         cat_list: List of categorical values found in the categorical column.
-        c_ratio: Dict {fold: percentage} mapping the percentage of all
-         categories to split folds.
+        c_ratio: Dict {fold: ratio} mapping the ratio of all categories to
+         split folds.
 
     Returns:
         cat_dict: Dict {fold: categorical_list} mapping lists of categorical
@@ -74,13 +74,14 @@ def partition_cat_list(cat_list: List[CategoricalValue],
     cat_dict = {}
 
     num_cats = len(cat_list)
+    sum_ratios = sum(c_ratio.values())
     ratio = 0
 
     # This might produce unexpected results if the number of categories
     # is lower than the number of folds.
     for fold, fold_pct in c_ratio.items():
         left_bound = round(num_cats * ratio)
-        ratio += fold_pct
+        ratio += fold_pct / sum_ratios
         right_bound = round(num_cats * ratio)
         # write categories for fold to the cat_list dict
         cat_dict[fold] = cat_list[left_bound:right_bound]


### PR DESCRIPTION
List of changes: 
- It is now possible to define a split configuration, where the ratios do not add up to 1, such as: `{'train': 1, 'eval': 1, 'test':1}` which corresponds to an equal three-way split.
- The quickstart notebook now features a `test` split on default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **CONTRIBUTING.md** document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
