### PR TITLE
Baris/sequencer category timestamp

### DIFF
--- a/zenml/steps/sequencer/base_sequencer.py
+++ b/zenml/steps/sequencer/base_sequencer.py
@@ -32,6 +32,8 @@ class BaseSequencerStep(BaseStep):
     STEP_TYPE = StepTypes.sequencer.name
 
     def __init__(self,
+                 keep_window_category: bool = False,
+                 keep_window_timestamp: bool = False,
                  statistics: DatasetFeatureStatisticsList = None,
                  schema: Schema = None,
                  **kwargs):
@@ -55,7 +57,12 @@ class BaseSequencerStep(BaseStep):
             schema: Parsed schema output of a preceding SchemaGen.
         """
 
-        super().__init__(**kwargs)
+        self.keep_window_category = keep_window_category
+        self.keep_window_timestamp = keep_window_timestamp
+
+        super().__init__(keep_window_category=keep_window_category,
+                         keep_window_timestamp=keep_window_timestamp,
+                         **kwargs)
 
         self.statistics = statistics
         self.schema = schema


### PR DESCRIPTION
List of changes:

- `BaseSequencerStep` is modified to accept two new parameters, namely `keep_window_category` and `keep_window_timestamp` which are utilized to persist the corresponding values within the context of the sequence.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **CONTRIBUTING.md** document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
